### PR TITLE
specify bash -e in genhooks

### DIFF
--- a/genhooks
+++ b/genhooks
@@ -1,4 +1,5 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+set -e
 
 if [ -z "$AS" ];      then AS="mips64-gcc";           fi
 if [ -z "$CC" ];      then CC="mips64-gcc";           fi


### PR DESCRIPTION
if you have zsh as your default shell, this printf will fail, i think due to the difference in how zsh handles expansion:
`./genhooks: line 26: printf: # 4 "src/gz/z64.h" 2: invalid number`
also, despite the error, the script (and makefile) will try to keep running. this should fix both of those issues.

you might also wanna check that `hooks_template` in `makefile` doesn't prevent itself from re-running upon failure; it kinda looks like the pipe will cause an empty file to be created, which makes `make` think the rule won't need to be run again, regardless of success.
