### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/.git
+.gitattributes
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+FROM alpine:3.9 as n64
+# Install build dependencies
+RUN apk --no-cache \
+    add --virtual build-dependencies \
+    wget \
+    tar \
+    make \
+    diffutils \
+    texinfo \
+    gcc \
+    g++ \
+    lua5.3-dev \
+    jansson-dev \
+    libusb-dev
+# Prepare workspace
+WORKDIR /usr/local/src/n64
+RUN wget \
+    --quiet \
+    --output-document - \
+    https://github.com/glankk/n64/tarball/master \
+    | tar xz --strip-components=1
+RUN LDFLAGS="-L/usr/lib/lua5.3" ./configure \
+    --prefix=/opt/n64 \
+    --enable-vc
+RUN make install-toolchain -j`cat /proc/cpuinfo | grep processor | wc -l`
+# Compile and install
+RUN make \
+    && make install \
+    && make install-sys
+
+FROM alpine:3.9 as gzinject
+# Install build dependencies
+RUN apk --no-cache \
+    add --virtual build-dependencies \
+    gcc \
+    musl-dev \
+    make
+# Prepare workspace
+WORKDIR /usr/local/src/gzinject
+RUN wget \
+    --quiet \
+    --output-document - \
+    https://github.com/krimtonz/gzinject/tarball/master \
+    | tar xz --strip-components=1
+# Fix unsupported argument
+RUN sed -i "s/--target-directory=/-t /" Makefile.in
+# Compile and install
+RUN ./configure --prefix=/opt/gzinject
+RUN make \
+    && make install
+
+# Final image
+FROM alpine:3.9
+RUN apk --no-cache add \
+    make \
+    jansson \
+    lua5.3
+COPY --from=n64 /opt/n64 /usr/local
+COPY --from=gzinject /opt/gzinject /usr/local
+WORKDIR /usr/local/src/gz
+COPY . .
+RUN make
+VOLUME ["/srv/OoT", "/var/gz-output"]
+CMD ["/bin/sh"]


### PR DESCRIPTION
# Add Dockerfile - Pull Request
This pull request adds a dockerfile to the repository. Using this it is possible to build an image with e.g. `docker build --tag gz .` if docker is installed on the machine. This image can be used to run a container with `docker run --interactive --tty --rm --volume <local dir with roms/wads>:/srv/OoT --volume <local dir for output>:/var/gz-output gz`. From there it is possible to easily creat patched roms or wads and copy them to `/var/gz-output` for consumption.

## Background
It can be cumbersome to maintain a clean and working environment for the gz environment. Cluttering the system with N64 compilation dependencies and having small version conflicts with libraries and similar can happen from time to time.

## Suggested Solution
Utilize a platform as a service using operating-system-level virtualization with containers. It does not matter which OS and which configuration the usage machine has. As long as it can run the container it will have a predictable and isolated environment. [Docker](https://www.docker.com/resources/what-container) is such a solution.