### PR TITLE
remove 32mb rom allocation fix as it's useless

### DIFF
--- a/patch/gzi/gz_NACE.gzi
+++ b/patch/gzi/gz_NACE.gzi
@@ -1,6 +1,0 @@
-# default gz patches for NACE
-0000 00000000 00000001
-# use 8MB memory
-0304 00002EB0 60000000
-# allocate 32MB for rom
-0304 0005BFD4 3C807200

--- a/patch/gzi/gz_NACJ.gzi
+++ b/patch/gzi/gz_NACJ.gzi
@@ -1,6 +1,0 @@
-# default gz patches for NACJ
-0000 00000000 00000001
-# use 8MB memory
-0304 00002EB0 60000000
-# allocate 32MB for rom
-0304 0005BF44 3C807200

--- a/patch/gzi/gz_mem_patch.gzi
+++ b/patch/gzi/gz_mem_patch.gzi
@@ -1,0 +1,4 @@
+# default gz memory patch for NACJ and NACE
+0000 00000000 00000001
+# use 8MB memory
+0304 00002EB0 60000000

--- a/patch/lua/make-wad.lua
+++ b/patch/lua/make-wad.lua
@@ -106,6 +106,7 @@ local gzinject_cmd = gzinject ..
                      " -a pack" ..
                      " -k \"" .. opt_keyfile .. "\"" ..
                      " -d \"" .. opt_directory .. "\"" ..
+                     " -p \"patch/gzi/gz_mem_patch.gzi\"" ..
                      " --verbose"
 if opt_id ~= nil then
   gzinject_cmd = gzinject_cmd .. " -i \"" .. opt_id .. "\""
@@ -123,7 +124,6 @@ else
   gzinject_cmd = gzinject_cmd .. " -r 3"
 end
 if vc_version ~= nil then
-  gzinject_cmd = gzinject_cmd .. " -p \"patch/gzi/gz_" .. vc_version .. ".gzi\""
   if not opt_nohb then
     gzinject_cmd = gzinject_cmd ..  " -p \"patch/gzi/hb_" .. vc_version ..
                    ".gzi\" --dol-inject \"patch/dol/hb-" .. vc_version ..


### PR DESCRIPTION
Removes the 32MB rom allocation "fix" as the emulator releases that allocation then allocates the actual ROM size.  