### PR TITLE
don't zero gz memory during dram initalization

### DIFF
--- a/patch/gzi/hb_NACE.gzi
+++ b/patch/gzi/hb_NACE.gzi
@@ -1,5 +1,7 @@
 # homeboy patches for NACE
 0000 00000000 00000001
+# dont zero gz memory
+0304 0003D320 3C800040
 # resize MEM2 heap for homeboy
 0302 00085732 00009010
 0304 00085738 60000000

--- a/patch/gzi/hb_NACJ.gzi
+++ b/patch/gzi/hb_NACJ.gzi
@@ -1,5 +1,7 @@
 # homeboy patches for NACJ
 0000 00000000 00000001
+# dont zero gz memory
+0304 0003D300 3C800040
 # resize MEM2 heap for homeboy
 0302 00085726 00009010
 0304 0008572C 60000000


### PR DESCRIPTION
sets memset's size to 4mb instead of total dram size to prevent gz's memory from being zero'd out.  