### PR TITLE
Create stub for __assert_func

### DIFF
--- a/src/gz/sys.c
+++ b/src/gz/sys.c
@@ -780,6 +780,12 @@ time_t time(time_t *tloc)
   return 0;
 }
 
+void __assert_func(const char *file, int line,
+                   const char *func, const char *failedexpr)
+{
+  return;
+}
+
 int sys_io_mode(int mode)
 {
   int p_mode = io_mode;

--- a/src/gz/sys.c
+++ b/src/gz/sys.c
@@ -780,6 +780,7 @@ time_t time(time_t *tloc)
   return 0;
 }
 
+__attribute__ ((used))
 void __assert_func(const char *file, int line,
                    const char *func, const char *failedexpr)
 {

--- a/src/gz/sys.h
+++ b/src/gz/sys.h
@@ -52,6 +52,8 @@ int             lstat(const char *path, struct stat *buf);
 int             chdir(const char *path);
 char           *getcwd(char *buf, size_t size);
 time_t          time(time_t *tloc);
+void            __assert_func(const char *file, int line,
+                              const char *func, const char *failedexpr);
 int             sys_io_mode(int mode);
 void            sys_reset(void);
 


### PR DESCRIPTION
Creates a stub for __assert_func to prevent linker warnings when compiling against newlib-3.2.0