### PR TITLE
Show short git commit sha on splash screen

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,8 +1,11 @@
-ifeq ($(origin PACKAGE_TARNAME), undefined)
-GIT_HASH             := $(shell git rev-parse --short HEAD 2>/dev/null)
-PACKAGE_TARNAME       = $(strip gz $(GIT_HASH))
-endif
+PACKAGE_TARNAME      ?= gz
 PACKAGE_URL          ?= github.com/glankk/gz
+ifeq ($(origin PACKAGE_VERSION), undefined)
+PACKAGE_VERSION      := $(shell git describe --tags --dirty 2>/dev/null)
+ifeq ('$(PACKAGE_VERSION)', '')
+PACKAGE_VERSION       = Unknown version
+endif
+endif
 target                = mips64
 program_prefix        = $(target)-
 AS                    = $(program_prefix)as
@@ -17,7 +20,7 @@ GENHOOKS              = AS='$(AS)' OBJCOPY='$(OBJCOPY)' NM='$(NM)' ./genhooks
 LUAPATCH              = luapatch
 GRC                   = AS='$(AS)' grc
 LDSCRIPT              = gl-n64.ld
-ALL_CPPFLAGS          = -DPACKAGE_TARNAME='$(PACKAGE_TARNAME)' -DPACKAGE_URL='$(PACKAGE_URL)' -DF3DEX_GBI_2 $(CPPFLAGS)
+ALL_CPPFLAGS          = -DPACKAGE_TARNAME='$(PACKAGE_TARNAME)' -DPACKAGE_URL='$(PACKAGE_URL)' -DPACKAGE_VERSION='$(PACKAGE_VERSION)' -DF3DEX_GBI_2 $(CPPFLAGS)
 ALL_CFLAGS            = -std=gnu11 -Wall -ffunction-sections -fdata-sections $(CFLAGS)
 ALL_CXXFLAGS          = -std=gnu++14 -Wall -ffunction-sections -fdata-sections $(CXXFLAGS)
 ALL_LDFLAGS           = -T $(LDSCRIPT) -L$(LIBDIR) -nostartfiles -specs=nosys.specs -Wl,--gc-sections $(LDFLAGS)

--- a/makefile
+++ b/makefile
@@ -1,4 +1,7 @@
-PACKAGE_TARNAME      ?= gz
+ifeq ($(origin PACKAGE_TARNAME), undefined)
+GIT_HASH             := $(shell git rev-parse --short HEAD 2>/dev/null)
+PACKAGE_TARNAME       = $(strip gz $(GIT_HASH))
+endif
 PACKAGE_URL          ?= github.com/glankk/gz
 target                = mips64
 program_prefix        = $(target)-

--- a/src/gz/gz.c
+++ b/src/gz/gz.c
@@ -406,9 +406,11 @@ static void main_hook(void)
       gfx_mode_set(GFX_MODE_COLOR, GPACK_RGBA8888(0xC0, 0x00, 0x00, alpha));
       const char *tarname = STRINGIFY(PACKAGE_TARNAME);
       const char *url = STRINGIFY(PACKAGE_URL);
-      gfx_printf(font, 20, Z64_SCREEN_HEIGHT - 10 - ch, tarname);
+      const char *version = STRINGIFY(PACKAGE_VERSION);
+      gfx_printf(font, 20, Z64_SCREEN_HEIGHT - 12 - ch * 2, tarname);
+      gfx_printf(font, 20, Z64_SCREEN_HEIGHT - 10 - ch, version);
       gfx_printf(font, Z64_SCREEN_WIDTH - 16 - cw * strlen(url),
-                 Z64_SCREEN_HEIGHT - 10 - ch, url);
+                 Z64_SCREEN_HEIGHT - 12 - ch * 2, url);
       if (!logo_texture)
         logo_texture = resource_load_grc_texture("logo");
       gfx_mode_set(GFX_MODE_COLOR, GPACK_RGBA8888(0xFF, 0xFF, 0xFF, alpha));
@@ -417,7 +419,7 @@ static void main_hook(void)
         {
           logo_texture, i,
           Z64_SCREEN_WIDTH - 16 - logo_texture->tile_width,
-          Z64_SCREEN_HEIGHT - 10 - ch * 2 -
+          Z64_SCREEN_HEIGHT - 12 - ch * 3 -
           (logo_texture->tiles_y - i) * logo_texture->tile_height,
           1.f, 1.f,
         };


### PR DESCRIPTION
A description of the current version will be shown on the splash screen. "Unknown version" will be shown in it's place if the version cannot be determined.

![gz with describe](https://user-images.githubusercontent.com/11130785/73127887-c289bf00-3f8c-11ea-97e2-b038b20729bc.jpg)

<details>
<summary>Appearance from first commit</summary>
<img src="https://user-images.githubusercontent.com/11130785/73115070-09bd7480-3ee7-11ea-8d3e-51589aaa9e0b.jpg" alt="gz with commit sha" />
</details>