### PR TITLE
Fix dynapoly collision not being freed when deleting an actor

### DIFF
--- a/src/gz/gz_debug.c
+++ b/src/gz/gz_debug.c
@@ -436,7 +436,9 @@ static void delete_actor_proc(struct menu_item *item, void *data)
     z64_actor_t *actor = z64_game.actor_list[adi->type].first;
     for (int i = 0; i < adi->index; ++i)
       actor = actor->next;
-    z64_DeleteActor(&z64_game, &z64_game.actor_ctxt, actor);
+    actor->draw_proc = NULL;
+    actor->main_proc = NULL;
+    actor->flags &= ~1;
   }
 }
 

--- a/src/gz/gz_debug.c
+++ b/src/gz/gz_debug.c
@@ -429,7 +429,7 @@ static void edit_actor_proc(struct menu_item *item, void *data)
   }
 }
 
-static void delete_actor_proc(struct menu_item *item, void *data)
+static void kill_actor_proc(struct menu_item *item, void *data)
 {
   struct actor_debug_info *adi = data;
   if (adi->index < z64_game.actor_list[adi->type].length) {
@@ -573,7 +573,7 @@ struct menu *gz_debug_menu(void)
   item->text = malloc(9);
   item->text[0] = 0;
   adi.edit_item = item;
-  menu_add_button(&actors, 0, 5, "delete", &delete_actor_proc, &adi);
+  menu_add_button(&actors, 0, 5, "kill", &kill_actor_proc, &adi);
   menu_add_button(&actors, 10, 5, "go to", &goto_actor_proc, &adi);
   /* actor spawn controls */
   static struct actor_spawn_info asi;


### PR DESCRIPTION
Replaces the call to `z64_DeleteActor` with code from the "actor kill" function the game normally uses to mark an actor to be deleted. This ensures all resources relating to the actor are freed as they would be if the actor were deleted by routines already present in the game, fixing the issue of dynapoly collision persisting after its associated actor has been deleted through the actor menu.