### PR TITLE
Automatically increment the savestate filename prefix

### DIFF
--- a/src/gz/files.c
+++ b/src/gz/files.c
@@ -520,3 +520,34 @@ void menu_get_file(struct menu *menu, enum get_file_mode mode,
   set_name(defname);
   menu_enter(menu, &gf_menu);
 }
+
+int get_next_prefix_number(const char *suffix)
+{
+  DIR *dir = opendir(".");
+  if (!dir) {
+    return 0;
+  }
+
+  int max_num_found = -1;
+  int sl = strlen(suffix);
+
+  /* enumerate entries */
+  struct dirent *dirent;
+  while ((dirent = readdir(dir))) {
+    if (!(dirent->mode & S_IRUSR))
+      continue;
+    int nl = strlen(dirent->d_name);
+    if (nl < sl || !stricmp(&dirent->d_name[nl - sl], suffix))
+      continue;
+    
+    int cur_num;
+    int ret = sscanf(dirent->d_name, "%d", &cur_num);
+    if (ret == EOF || ret < 1)
+      continue;
+    if (cur_num > max_num_found)
+      max_num_found = cur_num;
+  }
+
+  closedir(dir);
+  return max_num_found + 1;
+}

--- a/src/gz/files.h
+++ b/src/gz/files.h
@@ -6,6 +6,7 @@ enum get_file_mode
 {
   GETFILE_LOAD,
   GETFILE_SAVE,
+  GETFILE_SAVE_PREFIX_INC,
 };
 
 typedef int (*get_file_callback_t)(const char *path, void *data);
@@ -13,6 +14,5 @@ typedef int (*get_file_callback_t)(const char *path, void *data);
 void menu_get_file(struct menu *menu, enum get_file_mode mode,
                    const char *defname, const char *suffix,
                    get_file_callback_t callback_proc, void *callback_data);
-int get_next_prefix_number(const char *suffix);
 
 #endif

--- a/src/gz/files.h
+++ b/src/gz/files.h
@@ -13,5 +13,6 @@ typedef int (*get_file_callback_t)(const char *path, void *data);
 void menu_get_file(struct menu *menu, enum get_file_mode mode,
                    const char *defname, const char *suffix,
                    get_file_callback_t callback_proc, void *callback_data);
+int get_next_prefix_number(const char *suffix);
 
 #endif

--- a/src/gz/gz_macro.c
+++ b/src/gz/gz_macro.c
@@ -443,10 +443,9 @@ static void export_state_proc(struct menu_item *item, void *data)
   if (gz.state_buf[gz.state_slot]) {
     struct state_meta *state = gz.state_buf[gz.state_slot];
     char defname[32];
-    snprintf(defname, sizeof(defname), "%03d-%s",
-             get_next_prefix_number(".gzs"),
+    snprintf(defname, sizeof(defname), "000-%s",
              zu_scene_info[state->scene_idx].scene_name);
-    menu_get_file(gz.menu_main, GETFILE_SAVE, defname, ".gzs",
+    menu_get_file(gz.menu_main, GETFILE_SAVE_PREFIX_INC, defname, ".gzs",
                   do_export_state, NULL);
   }
 }

--- a/src/gz/gz_macro.c
+++ b/src/gz/gz_macro.c
@@ -443,7 +443,8 @@ static void export_state_proc(struct menu_item *item, void *data)
   if (gz.state_buf[gz.state_slot]) {
     struct state_meta *state = gz.state_buf[gz.state_slot];
     char defname[32];
-    snprintf(defname, sizeof(defname), "000-%s",
+    snprintf(defname, sizeof(defname), "%03d-%s",
+             get_next_prefix_number(".gzs"),
              zu_scene_info[state->scene_idx].scene_name);
     menu_get_file(gz.menu_main, GETFILE_SAVE, defname, ".gzs",
                   do_export_state, NULL);


### PR DESCRIPTION
I thought that the process of creating a new set of savestates for a route could be somewhat streamlined. When exporting a savestate, the suggested filename's prefix number will be the highest number at the start of a savestate filename plus 1. Numbers longer than 3 digits will not be truncated.

For example, for a directory containing:
```
000-lost woods.gzs
001-lost woods.gzs
```
the suggested filename would be `002-lost woods.gzs`.

The prefix will be automatically updated when changing directories if the filename has not otherwise been changed.