### PR TITLE
fix error when checking if a cluster is free

### DIFF
--- a/src/gz/fat.c
+++ b/src/gz/fat.c
@@ -488,7 +488,7 @@ static int get_clust(struct fat *fat, uint32_t clust, uint32_t *value)
     *value = get_word(block, offset, 4);
     *value &= 0x0FFFFFFF;
   }
-  if (clust == fat->free_lb && value != 0)
+  if (clust == fat->free_lb && *value != 0)
     ++fat->free_lb;
   return 0;
 }


### PR DESCRIPTION
Fixes an error when determining the first free cluster, It was checking if the pointer was null versus checking if the cluster value was 0, this would cause incorrect reporting of available free space in check_free_space, causing large files to incorrectly unable to allocate.