### PR TITLE
Minor fix for rewards obtained

### DIFF
--- a/src/gz/gz_file.c
+++ b/src/gz/gz_file.c
@@ -169,7 +169,7 @@ static void clear_intro_flags_proc(struct menu_item *item, void *data)
 
 static void set_reward_flags_proc(struct menu_item *item, void *data)
 {
-  zu_set_event_flag(0x19);
+  zu_set_event_flag(0x07);
   zu_set_event_flag(0x25);
   zu_set_event_flag(0x37);
   zu_set_event_flag(0x48);
@@ -180,7 +180,7 @@ static void set_reward_flags_proc(struct menu_item *item, void *data)
 
 static void clear_reward_flags_proc(struct menu_item *item, void *data)
 {
-  zu_clear_event_flag(0x19);
+  zu_clear_event_flag(0x07);
   zu_clear_event_flag(0x25);
   zu_clear_event_flag(0x37);
   zu_clear_event_flag(0x48);


### PR DESCRIPTION
The "rewards obtained" option currently doesn't affect the Deku Tree blue warp.
I propose to fix this by making it use flag 0x07 instead of 0x19.