### PR TITLE
Correct type of gs_flags

### DIFF
--- a/src/gz/flags.c
+++ b/src/gz/flags.c
@@ -241,7 +241,7 @@ void flag_menu_create(struct menu *menu)
   /* initialize data */
   vector_init(&records, sizeof(struct flag_record));
   vector_init(&events, sizeof(struct flag_event));
-  add_record(1, 56, z64_file.gs_flags, "gs");
+  add_record(4, 6, z64_file.gs_flags, "gs");
   add_record(2, 14, z64_file.event_chk_inf, "event_chk_inf");
   add_record(2, 4, z64_file.item_get_inf, "item_get_inf");
   add_record(2, 30, z64_file.inf_table, "inf_table");

--- a/src/gz/z64.h
+++ b/src/gz/z64.h
@@ -741,7 +741,9 @@ typedef struct
   uint32_t          fw_room_index;            /* 0x0E7C */
   int32_t           fw_set;                   /* 0x0E80 */
   char              unk_0xE84[0x0018];        /* 0x0E84 */
-  uint8_t           gs_flags[56];             /* 0x0E9C */
+  uint32_t          gs_flags[6];              /* 0x0E9C */
+  char              unk_EBC[0x0004];          /* 0x0EB4 */
+  int32_t           high_scores[7];           /* 0x0EB8 */
   uint16_t          event_chk_inf[14];        /* 0x0ED4 */
   uint16_t          item_get_inf[4];          /* 0x0EF0 */
   uint16_t          inf_table[30];            /* 0x0EF8 */


### PR DESCRIPTION
Change to `uint32_t` and adjust `flags.c` accordingly, they now display in the correct order. Split the array to separate off the high scores as well.