### PR TITLE
Change the default camera mode to "view"

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -162,11 +162,11 @@ trigger. These controls are disabled in the game when controlling the free
 camera. Press **lock** to disable the manual camera controls and restore the
 normal game controls.
 
-The free camera has two **mode** settings; when set to *camera*, the game's
+The free camera has two **mode** settings; when set to *view*, only the
+graphica viewpoint is changed. The game's camera then behaves as usual and is
+disjoint from the user's view of the scene. When set to *camera*, the game's
 camera is physically moved, which affects the behavior of in-game objects that
-react to the camera's position. When set to *view*, only the graphical
-viewpoint is changed. The game's camera then behaves as usual and is disjoint
-from the user's view of the scene.
+react to the camera's position.
 
 The **behavior** setting decides how the camera moves and how the controls
 work;

--- a/src/gz/gz.c
+++ b/src/gz/gz.c
@@ -1101,7 +1101,7 @@ static void init(void)
   gz.hide_actors = 0;
   gz.free_cam = 0;
   gz.lock_cam = 0;
-  gz.cam_mode = CAMMODE_CAMERA;
+  gz.cam_mode = CAMMODE_VIEW;
   gz.cam_bhv = CAMBHV_MANUAL;
   gz.cam_dist_min = 100;
   gz.cam_dist_max = 400;

--- a/src/gz/gz.h
+++ b/src/gz/gz.h
@@ -72,8 +72,8 @@ enum path_view_state
 
 enum cam_mode
 {
-  CAMMODE_CAMERA,
   CAMMODE_VIEW,
+  CAMMODE_CAMERA,
 };
 
 enum cam_bhv

--- a/src/gz/gz_scene.c
+++ b/src/gz/gz_scene.c
@@ -642,7 +642,7 @@ struct menu *gz_scene_menu(void)
   menu_add_static(&camera, 0, 2, "lock", 0xC0C0C0);
   menu_add_checkbox(&camera, 16, 2, lock_cam_proc, NULL);
   menu_add_static(&camera, 0, 3, "mode", 0xC0C0C0);
-  menu_add_option(&camera, 16, 3, "camera\0" "view\0", cam_mode_proc, NULL);
+  menu_add_option(&camera, 16, 3, "view\0" "camera\0", cam_mode_proc, NULL);
   menu_add_static(&camera, 0, 4, "behavior", 0xC0C0C0);
   menu_add_option(&camera, 16, 4,
                   "manual\0" "birdseye follow\0" "radial follow\0",


### PR DESCRIPTION
For me the "camera" mode is purely a desync footgun. Is there a reason why it's the default?