### PR TITLE
Don't save sSfxChannelState in states

### DIFF
--- a/src/gz/settings.h
+++ b/src/gz/settings.h
@@ -9,7 +9,7 @@
 #define SETTINGS_PADSIZE            ((sizeof(struct settings)+1)/2*2)
 #define SETTINGS_PROFILE_MAX        ((SETTINGS_MAXSIZE)/(SETTINGS_PADSIZE))
 #define SETTINGS_VERSION            0x0004
-#define SETTINGS_STATE_VERSION      0x0005
+#define SETTINGS_STATE_VERSION      0x0006
 #define SETTINGS_STATE_MIN_VER      0x0003
 
 #define SETTINGS_WATCHES_MAX        18

--- a/src/gz/state.c
+++ b/src/gz/state.c
@@ -1169,8 +1169,8 @@ uint32_t save_state(struct state_meta *state)
    *  D_8016B7A8
    *  D_8016B7AC
    *  D_8016B7B0
+   *  D_8016B7B4
    *  sRiverFreqScaleLerp
-   *  sWaterfallFreqScaleLerp
    *  sWaterfallFreqScaleLerp
    *  D_8016B7D8
    *  D_8016B7DC
@@ -1180,7 +1180,6 @@ uint32_t save_state(struct state_meta *state)
    *  sRiverSoundMainBgmLower
    *  sRiverSoundMainBgmRestore
    *  sGanonsTowerVol
-   *  sSfxChannelState
    *  sMalonSingingTimer
    *  sMalonSingingDisabled
    *  D_8016B9F3
@@ -1203,23 +1202,11 @@ uint32_t save_state(struct state_meta *state)
    *  sMusicStaffExpectedLength
    *  sMusicStaffExpectedPitch
    *  sScarecrowsLongSongSecondNote
-   *  sIsMalonSinging
-   *  sMalonSingingDist
-   *
-   *  Offset changes due to missing or changed debug variables;
-   *    sAudioUpdateStartTime       0x0000 - 0x0004 (- 0x0004)
-   *    sAudioUpdateEndTime         0x0004 - 0x0008 (- 0x0008)
-   *    -D_8016B7E4                 0x0044 - 0x0048 (- 0x000C)
-   *    sAudioScrPrtBuf             0x0048 - 0x0110 (- 0x00D4)
-   *    +D_8016B7E4                 0x0118 - 0x011C (- 0x00D0)
-   *    sBinToStrBuf                0x0218 - 0x0238 (- 0x00F0)
-   *    sAudioSpecPeakNumNotes      0x0240 - 0x0252 (- 0x0102)
-   *    +(alignment)                0x0264 - 0x0266 (- 0x0100)
-   *    sDebugPadHold & Co.         0x0310 - 0x0324 (- 0x0114)
    */
-  serial_write(&p, &code_800EC960_c_bss[0x0000], 0x0160); /* 10b overhead */
+  serial_write(&p, &code_800EC960_c_bss[0x0000], 0x0044); /* 6b overhead */
+  serial_write(&p, &code_800EC960_c_bss[0x0148], 0x0018); /* 2b overhead */
   serial_write(&p, &code_800EC960_c_bss[0x0168], 0x0004);
-  serial_write(&p, &code_800EC960_c_bss[0x0178], 0x0090);
+  serial_write(&p, &code_800EC960_c_bss[0x0178], 0x0088); /* 15b overhead */
 
   /*
    *  Variables from z_message_PAL.c(.data) (zeldaret/oot.git@8e04ae9)
@@ -2133,9 +2120,16 @@ void load_state(const struct state_meta *state)
     serial_read(&p, &code_800EC960_c_data[0x16F8], 0x0009);
     serial_read(&p, &code_800EC960_c_data[0x170C], 0x000A);
 #endif
-    serial_read(&p, &code_800EC960_c_bss[0x0000], 0x0160);
-    serial_read(&p, &code_800EC960_c_bss[0x0168], 0x0004);
-    serial_read(&p, &code_800EC960_c_bss[0x0178], 0x0090);
+    if (state->state_version >= 0x0006) {
+      serial_read(&p, &code_800EC960_c_bss[0x0000], 0x0044);
+      serial_read(&p, &code_800EC960_c_bss[0x0148], 0x0018);
+      serial_read(&p, &code_800EC960_c_bss[0x0168], 0x0004);
+      serial_read(&p, &code_800EC960_c_bss[0x0178], 0x0088);
+    } else {
+      serial_read(&p, &code_800EC960_c_bss[0x0000], 0x0160);
+      serial_read(&p, &code_800EC960_c_bss[0x0168], 0x0004);
+      serial_read(&p, &code_800EC960_c_bss[0x0178], 0x0090);
+    }
     serial_read(&p, z64_message_icon_state, 0x001E);
     serial_read(&p, z64_message_note_icon_state, 0x0006);
     serial_read(&p, &z_message_c_bss[0x0000], 0x0020);


### PR DESCRIPTION
Currently, if you're underwater and load a state back on land, some sound effects will still sound "underwater". This is likely because the `sSfxChannelState` i saved and reloaded, so when the state is restored the graphics thread in Audio_SetSfxProperties thinks that the sfx channel filters are already set correctly so it doesn't communicate the new filters to the audio thread.

I also removed `sIsMalonSinging` and `sMalonSingingDist` since these don't exist in retail (instead we were inadvertently saving and restoring the first 8 bytes of `D_8016BAD0`), and removed the comments about the debug version since they had multiple mistakes and it was tedious to fix. Now that retail decomp is (nearly) done these comments shouldn't be necessary anymore.

I tested in dolphin and it seems like the issue is gone