### PR TITLE
Fix scene explorer on Wii VC

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -575,13 +575,10 @@ _Note:_ Button combos that interfere with menu navigation for commands that
 aren't related to menuing are disabled while the utility menu is active.
 
 ## 3 VC Issues
-There are some known issues with the Wii VC version of gz;
-
--   The D-Pad on the Classic/Gamecube Controller is mapped to the L button on
-    the Virtual Console. The WAD patcher remaps the D-Pad to be functional
-    again, and maps C-Stick Down to L on the Virtual Console to provide access
-    to the utility menu.
--   The scene explorer has graphical glitches due to poor emulation.
+On Wii Virtual Console, the D-Pad on the Classic/Gamecube Controller is mapped
+to the L button. The WAD patcher remaps the D-Pad to be functional
+again, and maps C-Stick Down to L on the Virtual Console to provide access
+to the utility menu.
 
 ## 4 Issues with savestates
 


### PR DESCRIPTION
Currently the scene explorer on VC is broken because the Z buffer does not get cleared, meaning the room view clips into the background instead of being overlaid on top. It almost works to draw a transparent rectangle with a large "prim depth" instead, but the VC emulator implementation of gDPSetPrimDepth is buggy and doesn't work for depths other than 0. I've patched this in homeboy and the scene explorer works properly now.

I've tested both JP and US on Dolphin, and tested that N64 1.2 looks fine on Ares. Thanks to @Thar0 for help with the graphics commands here