### PR TITLE
Add 'ignore state's rng' checkbox to macro->settings menu

### DIFF
--- a/src/gz/gz_macro.c
+++ b/src/gz/gz_macro.c
@@ -703,6 +703,21 @@ static int byte_ztarget_proc(struct menu_item *item,
   return 0;
 }
 
+static int state_rng_proc(struct menu_item *item,
+                          enum menu_callback_reason reason,
+                          void *data)
+{
+  if (reason == MENU_CALLBACK_SWITCH_ON)
+    settings->bits.ignore_state_rng = 1;
+  else if (reason == MENU_CALLBACK_SWITCH_OFF)
+    settings->bits.ignore_state_rng = 0;
+  else if (reason == MENU_CALLBACK_THINK) {
+    if (menu_checkbox_get(item) != settings->bits.ignore_state_rng)
+      menu_checkbox_set(item, settings->bits.ignore_state_rng);
+  }
+  return 0;
+}
+
 struct menu *gz_macro_menu(void)
 {
   static struct menu menu;
@@ -814,6 +829,8 @@ struct menu *gz_macro_menu(void)
   menu_add_static(&menu_settings, 4, 7, "gc oob chu", 0xC0C0C0);
   menu_add_checkbox(&menu_settings, 2, 8, byte_ztarget_proc, NULL);
   menu_add_static(&menu_settings, 4, 8, "ignore state's z-target", 0xC0C0C0);
+  menu_add_checkbox(&menu_settings, 2, 9, state_rng_proc, NULL);
+  menu_add_static(&menu_settings, 4, 9, "ignore state's rng", 0xC0C0C0);
 
   /* populate virtual pad menu */
   menu_vcont.selector = menu_add_submenu(&menu_vcont, 0, 0, NULL, "return");

--- a/src/gz/settings.h
+++ b/src/gz/settings.h
@@ -138,6 +138,7 @@ struct settings_bits
   uint32_t holl_view_all    : 1;
   uint32_t watches_visible  : 1;
   uint32_t gc_oob_chu       : 1;
+  uint32_t ignore_state_rng : 1;
 };
 
 struct settings_data

--- a/src/gz/state.c
+++ b/src/gz/state.c
@@ -1850,7 +1850,12 @@ void load_state(const struct state_meta *state)
   serial_read(&p, &z64_gameover_countdown, sizeof(z64_gameover_countdown));
 
   /* rng */
-  serial_read(&p, &z64_random, sizeof(z64_random));
+  {
+    uint32_t rng;
+    serial_read(&p, &rng, sizeof(rng));
+    if (settings->bits.ignore_state_rng == 0 || gz.movie_state != MOVIE_IDLE)
+      z64_random = rng;
+  }
 
   /* spell states */
   if (state->state_version < 0x0004) {


### PR DESCRIPTION
This feature allows users to reload a state while leaving rng alone. This was requested for practicing rng-heavy sections particularly coming out of a cutscene like morpha/volv intro cs where there aren't good options for manipulating rng after regaining control (latest discussion https://discord.com/channels/82938430371139584/393062116015472640/1402734477230346272, I vaguely remember this coming up before as well) 

This setting is ignored if a macro is recording/playing, rng will always be restored in those cases. I don't think there's ever a case where it's useful to ignore rng when a macro is involved.
