### PR TITLE
Add 'keep lines' checkbox option to the actor debug menu

### DIFF
--- a/src/gz/gz.c
+++ b/src/gz/gz.c
@@ -390,6 +390,8 @@ static void main_hook(void)
       gfx_printf(font, x, y, "%d.%d", seconds, tenths);
   }
 
+  gz.actor_debug_info.menu_open = 0;
+
   /* draw menus */
   if (gz.menu_active)
     menu_draw(gz.menu_main);
@@ -402,6 +404,7 @@ static void main_hook(void)
   gz_path_view();
   gz_holl_view();
   gz_guard_view();
+  gz_actor_debug_view();
 
   /* execute free camera in view mode */
   gz_free_view();

--- a/src/gz/gz.h
+++ b/src/gz/gz.h
@@ -145,6 +145,15 @@ struct selected_actor
   int32_t               type;
 };
 
+struct actor_debug_info
+{
+  struct menu_item     *edit_item;
+  uint8_t               type;
+  uint8_t               index;
+  _Bool                 persistent;
+  _Bool                 menu_open;
+};
+
 struct gz
 {
   _Bool                 ready;
@@ -218,6 +227,7 @@ struct gz
   _Bool                 frame_flag;
   struct selected_actor selected_actor;
   int                   metronome_timer;
+  struct actor_debug_info actor_debug_info;
 };
 
 void          gz_apply_settings();
@@ -274,6 +284,7 @@ void          gz_cull_view(void);
 void          gz_path_view(void);
 void          gz_holl_view(void);
 void          gz_guard_view(void);
+void          gz_actor_debug_view(void);
 
 void          gz_update_cam(void);
 void          gz_free_view(void);


### PR DESCRIPTION
This feature adds a checkbox to the actor debug menu that when checked, persists the lines indicating the selected actor's position even after the menu is closed. This was recently requested in the practicerom discord channel; I initially thought it wasn't worth upstreaming but I'm told this is useful and happened to have a use for it myself recently, so figured I'd send it for review.
